### PR TITLE
add support for search strategies

### DIFF
--- a/.vim/after/syntax/quest.vim
+++ b/.vim/after/syntax/quest.vim
@@ -49,10 +49,11 @@ syn keyword questMacro include
 syn match questNA /N\/A/ contained
 syn keyword questStatus ACTIVE INACTIVE DONE UNREACHABLE PARENT
 syn keyword questHeuristic SIMPLE HSP
+syn keyword questStrategy ASTAR DFS
 syn keyword questKeywordQuest quest
 syn keyword questQuestParam preconditions goal actions objects subquests 
 syn keyword questQuestParam options searchLimit spaceLimit omega status 
-syn keyword questQuestParam heuristic use_atree
+syn keyword questQuestParam heuristic use_atree strategy
 syn keyword questActionBlock pre add rem
 
 
@@ -68,6 +69,7 @@ hi def link questMacro          Macro
 hi def link questNA             String
 hi def link questStatus         String
 hi def link questHeuristic      String
+hi def link questStrategy       String
 hi def link questKeyword        Keyword
 hi def link questKeywordType    Keyword
 hi def link questKeywordObject  Keyword

--- a/.vscode/extensions/libmozok-vscode-highlight-support/syntaxes/mozok-quest.tmLanguage.json
+++ b/.vscode/extensions/libmozok-vscode-highlight-support/syntaxes/mozok-quest.tmLanguage.json
@@ -23,7 +23,7 @@
 			"name": "comment.line.number-sign.quest"
 		},
 		"keywords": {
-			"match": "\\b(type|object|objects|version|project|include|rel|rlist|action|pre|add|rem|quest|main_quest|preconditions|goal|actions|subquests|status|ACTIVE|INACTIVE|DONE|UNREACHABLE|PARENT|N/A|options|searchLimit|spaceLimit|omega|heuristic|SIMPLE|HSP|use_atree)\\b",
+			"match": "\\b(type|object|objects|version|project|include|rel|rlist|action|pre|add|rem|quest|main_quest|preconditions|goal|actions|subquests|status|ACTIVE|INACTIVE|DONE|UNREACHABLE|PARENT|N/A|options|searchLimit|spaceLimit|omega|heuristic|SIMPLE|HSP|use_atree|strategy|ASTAR|DFS)\\b",
 			"name": "keyword.quest"
 		},
 		"integer": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All significant modifications to this project will be recorded in this file. The
 
 ## [Unreleased]
 
+## [0.2.1] - 2024-04-12
+
+### Added
+
+- Search strategies for quests (A\* and DFS).
+- `strategy ASTAR` and `strategy DFS` quest options.
+
+### Changed
+
+- Improved quest solver test.
+
 ## [0.2.0] - 2024-04-11
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,6 @@ Libmozok TODO list.
 - [ ] Use `std::move()` to transfer ownership of resources and reduce unnecessary copy operations where possible. Additionally, use `const T` (together with `std::move()`) instead of `const T&` in function signatures to indicate that data has been copied.
 - [ ] Ensure the order of the `status ...` commands in the save file matches the order in which they were triggered during the game-play.
 - [ ] Add: tags support for quicker navigation in vim/nvim for `.quest` files.
-- [ ] Add: support of both BFS & DFS as quest option `strategy BFS` and `strategy DFS`.
 
 ### In Progress
 
@@ -47,7 +46,8 @@ Libmozok TODO list.
 
 - [x] Add .quest `options:` section
     - [x] Make search and space limits as options
-    - [x] Add "omega" parameter for quests
+    - [x] Add: "omega" parameter for quests
+    - [x] Add: support of both A* & DFS search strategies as quest options `strategy ASTAR` and `strategy DFS`.
 
 - [x] Multithreading
     - [x] Introduce basic multithreading in the server by incorporating a worker sub-thread

--- a/docs/quest-format-reference.md
+++ b/docs/quest-format-reference.md
@@ -249,6 +249,9 @@ Keywords are reserved words and must not be used in naming.
 | `SIMPLE` | Simple heuristic (used in `heuristic`).
 | `HSP` | Heuristic from HSP algorithm (used in `heuristic`).
 | `use_atree` | This quest option forces to use action tree structure to boost the performance.
+| `strategy` | This quest option sets the search strategy (default `ASTAR`).
+| `ASTAR` | Search the plan using A\*.
+| `DFS` | Search in depth. For the cases when plan is long but straighforward.
 
 ### Statement
 

--- a/src/libmozok/libmozok/message_processor.cpp
+++ b/src/libmozok/libmozok/message_processor.cpp
@@ -48,8 +48,8 @@ void MessageProcessor::onNewSubQuest(
 { /* empty */ }
 
 void MessageProcessor::onNewQuestState(
-        const mozok::Str& worldName, 
-        const mozok::Str& questName
+        const mozok::Str& /*worldName*/, 
+        const mozok::Str& /*questName*/
         ) noexcept
 { /* empty */ }
 

--- a/src/libmozok/libmozok/project.cpp
+++ b/src/libmozok/libmozok/project.cpp
@@ -43,6 +43,9 @@ namespace {
     const char* KEYWORD_SIMPLE = "SIMPLE";
     const char* KEYWORD_HSP = "HSP";
     const char* KEYWORD_USE_ATREE = "use_atree";
+    const char* KEYWORD_STRATEGY = "strategy";
+    const char* KEYWORD_ASTAR = "ASTAR";
+    const char* KEYWORD_DFS = "DFS";
 }
 
 
@@ -847,8 +850,10 @@ public:
         int searchLimit = -1;
         int omega = -1;
         bool setHeuristic = false;
+        bool setStrategy = false;
         bool useActionTree = false;
         QuestHeuristic heuristic = QuestHeuristic::SIMPLE;
+        QuestSearchStrategy strategy = QuestSearchStrategy::ASTAR;
         res <<= empty_lines();
         res <<= space(1);
         if(keyword(KEYWORD_OPTIONS).isOk()) {
@@ -881,6 +886,23 @@ public:
                     } else if (heuristicName == KEYWORD_HSP) {
                         heuristic = QuestHeuristic::HSP;
                         setHeuristic = true;
+                    } else {    
+                        res <<= errorParserError(_file, _line, _col, 
+                            "Unknown heuristic name '" + heuristicName + "'");
+                    }
+                } else if(optionName == KEYWORD_STRATEGY) {
+                    res <<= space(1);
+                    Str strategyName;
+                    res <<= name(strategyName, UPPER);
+                    if(strategyName == KEYWORD_ASTAR) {
+                        strategy = QuestSearchStrategy::ASTAR;
+                        setStrategy = true;
+                    } else if (strategyName == KEYWORD_DFS) {
+                        strategy = QuestSearchStrategy::DFS;
+                        setStrategy = true;
+                    } else {    
+                        res <<= errorParserError(_file, _line, _col, 
+                            "Unknown strategy name '" + strategyName + "'");
                     }
                 } else if (optionName == KEYWORD_USE_ATREE) {
                     useActionTree = true;
@@ -974,6 +996,9 @@ public:
         if(setHeuristic)
             res <<= _world->setQuestOption(
                     questName, QUEST_OPTION_HEURISTIC, heuristic);
+        if(setStrategy)
+            res <<= _world->setQuestOption(
+                    questName, QUEST_OPTION_STRATEGY, strategy);
 
         if(res.isError())
             res <<= errorParserWorldError(

--- a/src/libmozok/libmozok/quest_manager.cpp
+++ b/src/libmozok/libmozok/quest_manager.cpp
@@ -9,6 +9,7 @@ const int DEFAULT_SEARCH_LIMIT = 1000;
 const int DEFAULT_SPACE_LIMIT = 10000;
 const int DEFAULT_OMEGA = 0;
 const QuestHeuristic DEFAULT_HEURISTIC = QuestHeuristic::SIMPLE;
+const QuestSearchStrategy DEFAULT_STRATEGY = QuestSearchStrategy::ASTAR;
 
 QuestManager::QuestManager(
         const QuestPtr& quest
@@ -22,7 +23,8 @@ QuestManager::QuestManager(
         /*.searchLimit = */DEFAULT_SEARCH_LIMIT,
         /*.spaceLimit = */DEFAULT_SPACE_LIMIT,
         /*.omega = */DEFAULT_OMEGA,
-        /*.heuristic = */DEFAULT_HEURISTIC
+        /*.heuristic = */DEFAULT_HEURISTIC,
+        /*.strategy = */DEFAULT_STRATEGY
     }),
     _parentQuest(nullptr),
     _parentQuestGoal(-1)
@@ -95,6 +97,9 @@ void QuestManager::setOption(
         break;
     case QUEST_OPTION_HEURISTIC:
         _settings.heuristic = QuestHeuristic(value);
+        break;
+    case QUEST_OPTION_STRATEGY:
+        _settings.strategy = QuestSearchStrategy(value);
         break;
     default:
         // skip

--- a/src/libmozok/libmozok/quest_manager.hpp
+++ b/src/libmozok/libmozok/quest_manager.hpp
@@ -21,7 +21,8 @@ enum QuestOption {
     QUEST_OPTION_SEARCH_LIMIT,
     QUEST_OPTION_SPACE_LIMIT,
     QUEST_OPTION_OMEGA,
-    QUEST_OPTION_HEURISTIC
+    QUEST_OPTION_HEURISTIC,
+    QUEST_OPTION_STRATEGY
 };
 
 enum QuestHeuristic {
@@ -29,6 +30,10 @@ enum QuestHeuristic {
     HSP
 };
 
+enum QuestSearchStrategy {
+    ASTAR,
+    DFS
+};
 
 /// @brief Quest settings for planner.
 struct QuestSettings {
@@ -44,6 +49,9 @@ struct QuestSettings {
 
     /// @brief Sets the heuristic function used during the A* search.
     QuestHeuristic heuristic;
+
+    /// @brief Sets the search strategy.
+    QuestSearchStrategy strategy;
 };
 
 

--- a/src/libmozok/libmozok/world.cpp
+++ b/src/libmozok/libmozok/world.cpp
@@ -815,7 +815,7 @@ void World::findNewSubquest(
             continue;
         if(!plan->givenState->hasSubstate(subquest->getPreconditions()))
             continue;
-        int goalIndx = 0;
+        //int goalIndx = 0;
         for(const Goal& goal : subquest->getGoals()) {
             if(post->hasSubstate(goal)) {
                 // New subquest has been found.
@@ -831,7 +831,7 @@ void World::findNewSubquest(
                 performQuestPlanning(subquestManager, messageProcessor);
                 break;
             }
-            ++goalIndx;
+            //++goalIndx;
         }
     }
 }

--- a/src/libmozok/tests/puzzles/main.cpp
+++ b/src/libmozok/tests/puzzles/main.cpp
@@ -162,7 +162,7 @@ int main(int argc, char **argv) {
 
     // Explicitly delete the quests server.
     status <<= server->deleteWorld(puzzle_name);
-    server.release();
+    server.reset();
 
     if(status.isError()) {
         cout << status.getDescription() << endl;

--- a/src/libmozok/tests/quests/make_sword.quest
+++ b/src/libmozok/tests/quests/make_sword.quest
@@ -207,6 +207,8 @@ action MakeSword:
 
 # One main quest without subquests.
 main_quest MakeSword_NoSubQuests:
+    options:
+        strategy DFS
     preconditions:
         NoSubQuests()
     goal:


### PR DESCRIPTION
- Search strategies for quests (A\* and DFS).
- `strategy ASTAR` and `strategy DFS` quest options.
- Improved quest solver test.
- Other minor changes (unique_ptr.release() bux fix in tests, warnings etc/)